### PR TITLE
Add GitHub action workflow to build wheels for Windows, Linux and Mac

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,0 +1,37 @@
+name: Build wheels
+
+on:
+  # Manually trigger
+  workflow_dispatch:
+  # Or push a tag
+  push:
+    tags:
+    - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.2.2
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      # Uploaded result can be found in Actions -> <select run> -> Artifacts
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pyclothoid-wheels
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
This adds an action workflow which lets you build all the wheels with a single click. You can then upload to pypi.

Later I can also show you how to extend this to additionally publish to the releases page based on a CHANGELOG.md file based on https://keepachangelog.com/en/1.0.0/