### PR TITLE
Expose maximum angle variation and divergence of SolveG2 function

### DIFF
--- a/pyclothoids/clothoid.py
+++ b/pyclothoids/clothoid.py
@@ -180,12 +180,12 @@ class Clothoid(object):
             return Clothoid.StandardParams(xp,yp,th,-self.KappaStart,-self.dk,self.length)
 
 
-def SolveG2(x0,y0,t0,k0,x1,y1,t1,k1):
+def SolveG2(x0,y0,t0,k0,x1,y1,t1,k1,Dmax=0,dmax=0):
     """
     Returns a tuple of three Clothoids that form a G2 continuous path that interpolates two cartesian
     endpoints, two tangents, and two curvatures
     """
     solver = G2solve3arc()
-    solver.build(x0,y0,t0,k0,x1,y1,t1,k1,0,0)
+    solver.build(x0,y0,t0,k0,x1,y1,t1,k1,Dmax,dmax)
     return tuple(map(Clothoid,(solver.getS0(),solver.getSM(),solver.getS1())))
 


### PR DESCRIPTION
Expose the parameters Dmax and dmax of the [G2solve3arc::build function](https://ebertolazzi.github.io/Clothoids/api-cpp/class_a00163.html#_CPPv4N5G2lib11G2solve3arc5buildE9real_type9real_type9real_type9real_type9real_type9real_type9real_type9real_type9real_type9real_type) with defaults set to zero as before. 

This allows to influence the length of the first and last clothoid as well as the overall curvature profile of the computed solution as explained in [Section 4](https://www.sciencedirect.com/science/article/pii/S0377042718301924?via%3Dihub#sec4) and [Section 6.1](https://www.sciencedirect.com/science/article/pii/S0377042718301924?via%3Dihub#sec6.1) of the underlying paper. 

The naming of the parameters does not fit the python style guide but matches the C++ API. 